### PR TITLE
fix: handle empty byte slices

### DIFF
--- a/bcs/decode.go
+++ b/bcs/decode.go
@@ -264,6 +264,10 @@ func (d *Decoder) decodeByteSlice(v reflect.Value) (int, error) {
 		return n, err
 	}
 
+	if size == 0 {
+		return n, nil
+	}
+
 	tmp := make([]byte, size)
 
 	read, err := d.reader.Read(tmp)

--- a/bcs/decode_test.go
+++ b/bcs/decode_test.go
@@ -154,3 +154,18 @@ func TestUnmarshal(t *testing.T) {
 		}
 	}
 }
+
+func TestEmptyByteSlice(t *testing.T) {
+	encoded, err := bcs.Marshal([]byte{})
+	if err != nil {
+		t.Error(err)
+	}
+	decoded := new([]byte)
+	n, err := bcs.Unmarshal(encoded, decoded)
+	if err != nil {
+		t.Error(err)
+	}
+	if n != 1 {
+		t.Errorf("want parsed length 1")
+	}
+}


### PR DESCRIPTION
currently when trying to decode an empty byte slice (`0x0`), it will result in EOF