### PR TITLE
Init nil pointer to support nested enums

### DIFF
--- a/bcs/decode.go
+++ b/bcs/decode.go
@@ -66,7 +66,12 @@ func (d *Decoder) decode(v reflect.Value) (int, error) {
 	// Enum
 	if _, isEnum := v.Interface().(Enum); isEnum {
 		switch v.Kind() {
-		case reflect.Pointer, reflect.Interface:
+		case reflect.Pointer:
+			if v.IsNil() {
+				v.Set(reflect.New(v.Type().Elem()))
+			}
+			return d.decodeEnum(v.Elem())
+		case reflect.Interface:
 			if v.IsNil() {
 				return 0, fmt.Errorf("trying to decode into nil pointer/interface")
 			}

--- a/bcs/enum_unmarshal_test.go
+++ b/bcs/enum_unmarshal_test.go
@@ -7,6 +7,13 @@ import (
 	"github.com/fardream/go-bcs/bcs"
 )
 
+type NestedEnum struct {
+	V0 *EnumExample
+	V1 *uint8
+}
+
+func (e NestedEnum) IsBcsEnum() {}
+
 func TestEnum_Unmarshal(t *testing.T) {
 	cases := [][]byte{
 		{0, 42},
@@ -16,6 +23,37 @@ func TestEnum_Unmarshal(t *testing.T) {
 
 	for _, v := range cases {
 		e := &EnumExample{}
+
+		n, err := bcs.Unmarshal(v, e)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if n != len(v) {
+			t.Errorf("want parsed length: %d, got: %d", len(v), n)
+		}
+
+		nb, err := bcs.Marshal(e)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if !slices.Equal(nb, v) {
+			t.Errorf("want %v, got %v", v, nb)
+		}
+	}
+}
+
+func TestNestedEnum_Unmarshal(t *testing.T) {
+	cases := [][]byte{
+		{0, 0, 42},
+		{1, 0},
+		{1, 42},
+		{0, 4, 3, 97, 98, 99},
+	}
+
+	for _, v := range cases {
+		e := &NestedEnum{}
 
 		n, err := bcs.Unmarshal(v, e)
 		if err != nil {


### PR DESCRIPTION
Currently nested enum structures can't be parsed because the decoder refuses to step into a nil struct. Callers can't (shouldn't) work around this by initialising the top level enum full of zero values (since nil-ness is important for deciding which case to select).

The PR initialises the nil pointer to the type's zero when stepping into a nil enum (similar to the strategy immediately below for non enum cases). 