### PR TITLE
Test pointer version of type for unmarshal interface when decoding

### DIFF
--- a/bcs/decode.go
+++ b/bcs/decode.go
@@ -58,8 +58,13 @@ func (d *Decoder) decode(v reflect.Value) (int, error) {
 		return 0, nil
 	}
 
+	vAddr := v
+	if v.Kind() != reflect.Pointer && v.CanAddr() {
+		vAddr = v.Addr()
+	}
+
 	// Unmarshaler
-	if i, isUnmarshaler := v.Interface().(Unmarshaler); isUnmarshaler {
+	if i, isUnmarshaler := vAddr.Interface().(Unmarshaler); isUnmarshaler {
 		return i.UnmarshalBCS(d.reader)
 	}
 

--- a/bcs/enum_unmarshal_test.go
+++ b/bcs/enum_unmarshal_test.go
@@ -1,6 +1,8 @@
 package bcs_test
 
 import (
+	"errors"
+	"io"
 	"slices"
 	"testing"
 
@@ -54,6 +56,70 @@ func TestNestedEnum_Unmarshal(t *testing.T) {
 
 	for _, v := range cases {
 		e := &NestedEnum{}
+
+		n, err := bcs.Unmarshal(v, e)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if n != len(v) {
+			t.Errorf("want parsed length: %d, got: %d", len(v), n)
+		}
+
+		nb, err := bcs.Marshal(e)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if !slices.Equal(nb, v) {
+			t.Errorf("want %v, got %v", v, nb)
+		}
+	}
+}
+
+type Foo struct {
+	A CustomUnmarshal
+}
+
+type CustomUnmarshal struct {
+	IsInt int
+}
+
+func (u *CustomUnmarshal) UnmarshalBCS(r io.Reader) (int, error) {
+	b := make([]byte, 1)
+	if n, err := io.ReadFull(r, b); err != nil {
+		return n, err
+	}
+
+	if b[0] == 0 {
+		u.IsInt = 0
+	} else if b[0] == 1 {
+		u.IsInt = 1
+	} else {
+		return len(b), errors.New("invalid")
+	}
+
+	return len(b), nil
+}
+
+func (u CustomUnmarshal) MarshalBCS() ([]byte, error) {
+	if u.IsInt == 0 {
+		return []byte{0}, nil
+	} else if u.IsInt == 1 {
+		return []byte{1}, nil
+	} else {
+		return nil, errors.New("invalid")
+	}
+}
+
+func TestNestedCustom_Unmarshal(t *testing.T) {
+	cases := [][]byte{
+		{0},
+		{1},
+	}
+
+	for _, v := range cases {
+		e := &Foo{}
 
 		n, err := bcs.Unmarshal(v, e)
 		if err != nil {


### PR DESCRIPTION
`Unmarshaler` needs to be implemented on a pointer receiver for any given type (since the data needs to be written into the type). There is of course no good way to implement `Unmarshaler` on a non-pointer, but it is still useful for non pointers to be included in a type structure when interfacing with the bcs library.

During decoding, when a non-pointer is encountered (with an Unmarshaler impl available on the pointer to that type), this implementation is not correctly identified due to the non-pointer version of the type not implementing Unmarshaler.

To *address* this, I've added a check which will ensure that we test a pointer for the `Unmarshaler` interface during decoding. If the type is already a pointer, there is nothing to be done: but if the type is not a pointer (but can be addressed), then we instead take the address of the value and test that for `Unmarshaler`.

This is inspired by how `encoding/json` [deals with this](https://cs.opensource.google/go/go/+/refs/tags/go1.23.4:src/encoding/json/decode.go;l=427-447).

`encoding/json` additionally checks that `v.Type().Name() != ""`. I think this is added to avoid bothering to check things like anonymous structs, but I'm not 100%. I don't think there is any harm in omitting this test if that's the case (for this library's uses), since anonymous structs shouldn't be able to implement `Unmarshaler` anyway.