### PR TITLE
Add convenience variant for Unmarshal which errors if bytes are leftover

### DIFF
--- a/bcs/decode.go
+++ b/bcs/decode.go
@@ -20,6 +20,21 @@ func Unmarshal(data []byte, v any) (int, error) {
 	return NewDecoder(bytes.NewReader(data)).Decode(v)
 }
 
+// UnmarshalAll is like [Unmarshal], but will additionally error if the input
+// bytes are not completely consumed by the call to [Unmarshal].
+//
+// This is useful for ensuring that a particular set of bytes *completely* represents
+// the data it is decoded to (i.e. no bytes are left over after decoding).
+func UnmarshalAll(data []byte, v any) error {
+	if n, err := NewDecoder(bytes.NewReader(data)).Decode(v); err != nil {
+		return err
+	} else if n != len(data) {
+		return fmt.Errorf("did not unmarshal all bytes, got %d expected %d", n, len(data))
+	}
+
+	return nil
+}
+
 // Decoder takes an [io.Reader] and decodes value from it.
 type Decoder struct {
 	reader     io.Reader


### PR DESCRIPTION
Because BCS is a canonical format, often callers may expect that a particular set of bytes is *completely* consumed by the Unmarshal operation (ie. that the original bytes decode *exactly* to the result, with nothing leftover).

This MR allows callers to encode that expectation in a call to `UnmarshalAll`, which will error if any bytes remain after the decode operation.