### PR TITLE
Validate field number when parsing enum

### DIFF
--- a/bcs/decode.go
+++ b/bcs/decode.go
@@ -275,6 +275,10 @@ func (d *Decoder) decodeEnum(v reflect.Value) (int, error) {
 		return n, err
 	}
 
+	if enumId >= v.NumField() {
+		return n, fmt.Errorf("enum field %d is out of range", enumId)
+	}
+
 	field := v.Field(enumId)
 
 	k, err := d.decode(field)

--- a/bcs/enum_unmarshal_test.go
+++ b/bcs/enum_unmarshal_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/fardream/go-bcs/bcs"
+	"github.com/stretchr/testify/require"
 )
 
 type NestedEnum struct {
@@ -43,6 +44,22 @@ func TestEnum_Unmarshal(t *testing.T) {
 		if !slices.Equal(nb, v) {
 			t.Errorf("want %v, got %v", v, nb)
 		}
+	}
+}
+
+func TestEnumInvalid_Unmarshal(t *testing.T) {
+	cases := [][]byte{
+		{5, 42},
+	}
+
+	for _, v := range cases {
+		e := &EnumExample{}
+
+		require.NotPanics(t, func() {
+			n, err := bcs.Unmarshal(v, e)
+			require.Error(t, err)
+			require.Equal(t, 1, n)
+		})
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/fardream/go-bcs
 
 go 1.21
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)


### PR DESCRIPTION
Calling `v.Field(enumId)` will cause a panic if the enumId is out of the field range. Added a check to ensure we error before this call if the ID is not valid.