### PR TITLE
decode enum: allocate memory is field is pointer and nil

### DIFF
--- a/bcs/decode.go
+++ b/bcs/decode.go
@@ -281,6 +281,11 @@ func (d *Decoder) decodeEnum(v reflect.Value) (int, error) {
 
 	field := v.Field(enumId)
 
+	// Initialize nil pointer fields before decoding
+	if field.Kind() == reflect.Ptr && field.IsNil() {
+		field.Set(reflect.New(field.Type().Elem()))
+	}
+
 	k, err := d.decode(field)
 	n += k
 


### PR DESCRIPTION
This allows unmarshal into nested enum/structs without pre-allocating memory for each field. 

E.g. : the following should now succeed instead of throwing a  `panic: trying to decode into nil pointer/interface`

```go 
tx := &suiptb.TransactionData{}
numBytes, err = bcs.Unmarshal(txData, tx)
```

```go 
type TransactionData struct {
	V1 *TransactionDataV1
}

func (t TransactionData) IsBcsEnum() {}

type TransactionDataV1 struct {
	Kind       TransactionKind
	Sender     sui.Address
	GasData    GasData
	Expiration TransactionExpiration
}

type TransactionKind struct {
	ProgrammableTransaction *ProgrammableTransaction
	ChangeEpoch             *ChangeEpoch
	Genesis                 *GenesisTransaction
	ConsensusCommitPrologue *ConsensusCommitPrologue
}

func (t TransactionKind) IsBcsEnum() {}
```