### PR TITLE
Fix unbounded upfront allocations

### DIFF
--- a/bcs/decode.go
+++ b/bcs/decode.go
@@ -188,10 +188,11 @@ func (d *Decoder) decodeString(v reflect.Value) (int, error) {
 		return n, nil
 	}
 
-	tmp := make([]byte, size)
-
-	read, err := d.reader.Read(tmp)
+	r := io.LimitReader(d.reader, int64(size))
+	tmp, err := io.ReadAll(r)
+	read := len(tmp)
 	n += read
+
 	if err != nil {
 		return n, err
 	}
@@ -302,10 +303,11 @@ func (d *Decoder) decodeByteSlice(v reflect.Value) (int, error) {
 		return n, nil
 	}
 
-	tmp := make([]byte, size)
-
-	read, err := d.reader.Read(tmp)
+	r := io.LimitReader(d.reader, int64(size))
+	tmp, err := io.ReadAll(r)
+	read := len(tmp)
 	n += read
+
 	if err != nil {
 		return n, err
 	}
@@ -359,8 +361,8 @@ func (d *Decoder) decodeSlice(v reflect.Value) (int, error) {
 
 	// element type of the slice
 	elementType := v.Type().Elem()
-	// make a new slice
-	tmp := reflect.MakeSlice(v.Type(), 0, size)
+	// make a new slice; we don't pre-allocate to prevent DoS
+	tmp := reflect.MakeSlice(v.Type(), 0, 0)
 
 	if elementType.Kind() == reflect.Pointer {
 		for i := 0; i < size; i++ {

--- a/bcs/decode_bench_test.go
+++ b/bcs/decode_bench_test.go
@@ -1,6 +1,7 @@
 package bcs_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/fardream/go-bcs/bcs"
@@ -12,76 +13,97 @@ func BenchmarkDecodeSlice(b *testing.B) {
 		Name  string
 	}
 
-	// Create test data with a slice of structs
-	testData := []TestStruct{
-		{Value: 1, Name: "first"},
-		{Value: 2, Name: "second"},
-		{Value: 3, Name: "third"},
-		{Value: 4, Name: "fourth"},
-		{Value: 5, Name: "fifth"},
-	}
+	sizes := []int{16, 256, 4096}
 
-	// Marshal the data once
-	encoded, err := bcs.Marshal(testData)
-	if err != nil {
-		b.Fatal(err)
-	}
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("size_%d", size), func(b *testing.B) {
+			// Create test data with specified size
+			testData := make([]TestStruct, size)
+			for i := 0; i < size; i++ {
+				testData[i] = TestStruct{
+					Value: int32(i),
+					Name:  fmt.Sprintf("item_%d", i),
+				}
+			}
 
-	b.ResetTimer()
-	b.ReportAllocs()
+			// Marshal the data once
+			encoded, err := bcs.Marshal(testData)
+			if err != nil {
+				b.Fatal(err)
+			}
 
-	for i := 0; i < b.N; i++ {
-		var result []TestStruct
-		_, err := bcs.Unmarshal(encoded, &result)
-		if err != nil {
-			b.Fatal(err)
-		}
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				var result []TestStruct
+				_, err := bcs.Unmarshal(encoded, &result)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }
 
 func BenchmarkDecodeString(b *testing.B) {
-	// Create test string
-	testString := "This is a test string for benchmarking BCS string deserialization"
+	sizes := []int{16, 256, 4096}
 
-	// Marshal the string once
-	encoded, err := bcs.Marshal(testString)
-	if err != nil {
-		b.Fatal(err)
-	}
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("size_%d", size), func(b *testing.B) {
+			// Create test string of specified size
+			testString := make([]byte, size)
+			for i := range testString {
+				testString[i] = byte('a' + (i % 26))
+			}
 
-	b.ResetTimer()
-	b.ReportAllocs()
+			// Marshal the string once
+			encoded, err := bcs.Marshal(string(testString))
+			if err != nil {
+				b.Fatal(err)
+			}
 
-	for i := 0; i < b.N; i++ {
-		var result string
-		_, err := bcs.Unmarshal(encoded, &result)
-		if err != nil {
-			b.Fatal(err)
-		}
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				var result string
+				_, err := bcs.Unmarshal(encoded, &result)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }
 
 func BenchmarkDecodeByteSlice(b *testing.B) {
-	// Create test byte slice
-	testBytes := make([]byte, 256)
-	for i := range testBytes {
-		testBytes[i] = byte(i)
-	}
+	sizes := []int{16, 256, 4096}
 
-	// Marshal the byte slice once
-	encoded, err := bcs.Marshal(testBytes)
-	if err != nil {
-		b.Fatal(err)
-	}
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("size_%d", size), func(b *testing.B) {
+			// Create test byte slice of specified size
+			testBytes := make([]byte, size)
+			for i := range testBytes {
+				testBytes[i] = byte(i % 256)
+			}
 
-	b.ResetTimer()
-	b.ReportAllocs()
+			// Marshal the byte slice once
+			encoded, err := bcs.Marshal(testBytes)
+			if err != nil {
+				b.Fatal(err)
+			}
 
-	for i := 0; i < b.N; i++ {
-		var result []byte
-		_, err := bcs.Unmarshal(encoded, &result)
-		if err != nil {
-			b.Fatal(err)
-		}
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				var result []byte
+				_, err := bcs.Unmarshal(encoded, &result)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }

--- a/bcs/decode_bench_test.go
+++ b/bcs/decode_bench_test.go
@@ -1,0 +1,87 @@
+package bcs_test
+
+import (
+	"testing"
+
+	"github.com/fardream/go-bcs/bcs"
+)
+
+func BenchmarkDecodeSlice(b *testing.B) {
+	type TestStruct struct {
+		Value int32
+		Name  string
+	}
+
+	// Create test data with a slice of structs
+	testData := []TestStruct{
+		{Value: 1, Name: "first"},
+		{Value: 2, Name: "second"},
+		{Value: 3, Name: "third"},
+		{Value: 4, Name: "fourth"},
+		{Value: 5, Name: "fifth"},
+	}
+
+	// Marshal the data once
+	encoded, err := bcs.Marshal(testData)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		var result []TestStruct
+		_, err := bcs.Unmarshal(encoded, &result)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDecodeString(b *testing.B) {
+	// Create test string
+	testString := "This is a test string for benchmarking BCS string deserialization"
+
+	// Marshal the string once
+	encoded, err := bcs.Marshal(testString)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		var result string
+		_, err := bcs.Unmarshal(encoded, &result)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDecodeByteSlice(b *testing.B) {
+	// Create test byte slice
+	testBytes := make([]byte, 256)
+	for i := range testBytes {
+		testBytes[i] = byte(i)
+	}
+
+	// Marshal the byte slice once
+	encoded, err := bcs.Marshal(testBytes)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		var result []byte
+		_, err := bcs.Unmarshal(encoded, &result)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/bcs/decode_test.go
+++ b/bcs/decode_test.go
@@ -3,6 +3,7 @@ package bcs_test
 import (
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/fardream/go-bcs/bcs"
@@ -202,12 +203,10 @@ func TestLargeDeclaredSize(t *testing.T) {
 	// Set the declared size to be the maximum value
 	buf, _ := bcs.ULEB128Encode(1<<31 - 1)
 
-	// Unmarshalling this small input with large declared size should not cause an out-of-memory panic.
+	// Unmarshaling this small input with large declared size should fail gracefully
+	// because there's not enough data to read the declared number of elements.
 	err := bcs.UnmarshalAll(buf, &data)
-	if err != nil {
-		t.Fatalf("failed to unmarshal: %v", err)
-	}
-	if len(data) != 0 {
-		t.Fatalf("expected empty result, got %d elements", len(data))
+	if err == nil || !strings.Contains(err.Error(), "EOF") {
+		t.Fatalf("expected unmarshaling to fail with insufficient data")
 	}
 }

--- a/bcs/decode_test.go
+++ b/bcs/decode_test.go
@@ -195,3 +195,19 @@ func TestEmptyByteSlice(t *testing.T) {
 		t.Errorf("want parsed length 1")
 	}
 }
+
+func TestLargeDeclaredSize(t *testing.T) {
+	var data [][64]string
+
+	// Set the declared size to be the maximum value
+	buf, _ := bcs.ULEB128Encode(1<<31 - 1)
+
+	// Unmarshalling this small input with large declared size should not cause an out-of-memory panic.
+	err := bcs.UnmarshalAll(buf, &data)
+	if err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("expected empty result, got %d elements", len(data))
+	}
+}


### PR DESCRIPTION
Vector decoding currently pre-allocates a slice of values based on the size field of the encoded vector, regardless of whether the supplied payload is actually big enough to encode the declared amount of data.

Encoded data is generally assumed to be untrusted. Maliciously encoded data can declare a length much longer than the actual payload, see below. Currently this causes runaway memory allocation and system freeze (tested on MacOS). 

This patch defers allocation until data is actually read from the payload. This prevents asymmetric resource uses and allows for effective bounding of resource usage by bounding total payload size (e.g. with HTTP request size limits).

This patch does not change the API or observable behavior when decoding honestly-encoded messages.


Test to demonstrate the issue:
```go
func TestLargeDeclaredSize(t *testing.T) {
	var data [][64]string

	// Set the declared size to be the maximum value
	buf, _ := bcs.ULEB128Encode(1<<31 - 1)

	// Unmarshaling this small input with large declared size should fail gracefully
	// because there's not enough data to read the declared number of elements.
	err := bcs.UnmarshalAll(buf, &data)
	if err == nil || !strings.Contains(err.Error(), "EOF") {
		t.Fatalf("expected unmarshaling to fail with insufficient data")
	}
}
```